### PR TITLE
[feat084] 배달원이 배정완료 버튼을 누르면 고객에게 까지의 ETA를 계산해 DB에 저장하고 고객이 볼 수 있도록 함

### DIFF
--- a/app/customer/templates/orders/list.html
+++ b/app/customer/templates/orders/list.html
@@ -34,7 +34,7 @@
                 {% elif order.order_status == "crew_accepted" %}
                     기사님 배정 됨
                 {% elif order.order_status == "delivery_in_progress" %}
-                    배달 중
+                    배달 중&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;소요시간 : {{ order.eta }}분
                 {% elif order.order_status == "delivered" %}
                     배달 완료
                 {% endif %}

--- a/app/delivery_crew/templates/history_detail.html
+++ b/app/delivery_crew/templates/history_detail.html
@@ -109,7 +109,6 @@
 						var pointType = mData.properties.pointType;
 						if(type == "Point"){
 							var linePt = new Tmapv3.LatLng(mData.geometry.coordinates[1],mData.geometry.coordinates[0]);
-							console.log(linePt);
 							PTbounds.extend(linePt);
 						}
 						else{
@@ -149,8 +148,6 @@
                 map: map
             });	
 
-            const startX = 126.9837016;
-            const startY = 37.5665048;
             const headers = new Headers();
             headers.append("appKey", "kyUPwz0Ly2aplTsQ72YKp2EjfDwbI0EJ9KFRwUA4");
             fetch("https://apis.openapi.sk.com/tmap/routes?version=3&format=json", {
@@ -167,8 +164,6 @@
                     trafficInfo: "Y",
                     carType: 7,
                 }),
-                mode: "cors",
-                cache: "no-cache"
             })
             .then(response => response.json())
             .then(data => {

--- a/app/delivery_crew/test.py
+++ b/app/delivery_crew/test.py
@@ -1,0 +1,23 @@
+import requests
+
+
+url = "https://apis.openapi.sk.com/tmap/routes?version=3&format=json"
+headers = {"appKey": "kyUPwz0Ly2aplTsQ72YKp2EjfDwbI0EJ9KFRwUA4"}
+data = {
+    "startX": 126.98446467,
+    "startY": 37.57539772,
+    "endX": 127.02493533,
+    "endY": 37.50049048,
+    "reqCoordType": "WGS84GEO",
+    "resCoordType": "WGS84GEO",
+    "searchOption": "0",
+    "trafficInfo": "Y",
+    "carType": 7,
+    "totalValue": 2,
+}
+resp = requests.post(url, headers=headers, data=data).json()
+print(resp)
+eta = resp["features"][0]["properties"]["totalTime"] // 60
+
+print(resp["features"][0]["properties"]["totalTime"] // 60)
+print(eta)

--- a/app/sajjang/models.py
+++ b/app/sajjang/models.py
@@ -100,6 +100,7 @@ class Order(models.Model):
     # delivery_status = models.BooleanField(
     #     null=True, default=None, verbose_name="delivery_status"
     # )
+    eta = models.IntegerField(null=True)
     created_at = models.DateTimeField(auto_now_add=True, null=True)
     updated_at = models.DateTimeField(auto_now=True)
 


### PR DESCRIPTION
API를 통한 ETA는 초 단위로 전달받지만 배달원의 여유를 위해
1. 초 단위 시간을 분으로 변환
2. 1의 자리 숫자를 없앤 후 10 분 추가 -> 기존 4분 -> 10분, 기존 13분 -> 20분
3. Order 모델의 ETA는 분 단위로 기록

고객은 배달중인 주문 목록만 ETA를 볼 수 있도록 수정함

customer/templates/orders/list.html -> [ADD] 배달중인 목록에 소요시간 표시 
delivery_crew/views.py -> [ADD] ETA 요청을 위한 주소 -> 좌표값 변환 함수, 두 좌표의 경로안내를 통한 ETA를 받아올 api 호출 함수 추가
delivery_crew/templates/history_detail.html -> [DEL] 불필요한 변수 선언문 및 리퀘스트 속성 삭제, 콘솔 출력 삭제 
sajjang/models.py -> [ADD] Order 모델 eta 컬럼 추가